### PR TITLE
Enable XML editor

### DIFF
--- a/startapp.sh
+++ b/startapp.sh
@@ -6,4 +6,5 @@
 # ↓↓↓ PUT COMAMNDS HERE ↓↓↓
 dbus-launch gsettings set org.virt-manager.virt-manager.connections uris "$HOSTS"
 dbus-launch gsettings set org.virt-manager.virt-manager.connections autoconnect "$HOSTS"
+dbus-launch gsettings set org.virt-manager.virt-manager xmleditor-enabled true
 virt-manager --no-fork


### PR DESCRIPTION
Hello!

First of all, thank you for the container, it helps me manage VMs created on Unraid. This PR aims to enable the xml editor in order to bypass a bug when trying to create a new USB device for passthrough.