### PR TITLE
Manual about using of ssh-agent instead of copying ssh private keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,94 @@ services:
       # If not using password auth, substitute location of ssh private key, e.g.:
       # - /home/user/.ssh/id_rsa:/root/.ssh/id_rsa:ro
 ```
+
+### SSH Keys and SSH agent forwarding
+
+There are few options how to deal with ssh. 
+
+#### Mount ssh key as a volume
+
+You may use straight-forward approach and mount ssh private key to the container. This approach is described above and
+you may simply to add the following volume to the `docker-compose.yml`
+
+```yaml
+services: 
+  virt-manager:
+    image: mber5/virt-manager:latest
+    restart: always
+    ports:
+      - 8185:80
+    environment:
+      DARK_MODE: false
+      HOSTS: "[]"
+    volumes:
+      - "/home/user/.ssh/id_rsa:/root/.ssh/id_rsa:ro"
+```
+
+Where `/home/user/.ssh/id_rsa` is a path to your private key on the host machine. You will be asked for passphrase all
+the time and this is annoying.
+
+#### Use ssh-agent and mount SSH_AUTH_SOCK
+
+**For Linux host machines.**
+
+Check that `ssh-agent` is running, add `ssh` key to the agent, check that `ssh` connections use `ssh-agent`. You may
+[read this article](https://www.cyberciti.biz/faq/how-to-use-ssh-agent-for-authentication-on-linux-unix/)
+explaining these commands.
+
+Check that `$SSH_AUTH_SOCK` env variable exists.
+
+```bash
+$ echo $SSH_AUTH_SOCK
+/tmp/ssh-5n3we7jOrV/agent.582768
+```
+
+After that, add to the `docker-compose.yml` following sections
+
+```yaml
+services: 
+  virt-manager:
+    image: mber5/virt-manager:latest
+    restart: always
+    ports:
+      - 8185:80
+    environment:
+      DARK_MODE: false
+      HOSTS: "[]"
+      SSH_AUTH_SOCK: "/tmp/ssh_auth.sock"
+    volumes:
+      - "${SSH_AUTH_SOCK}:/tmp/ssh_auth.sock"
+```
+
+Now in your container you have `/tmp/ssh_auth.sock` socket to the `ssh-agent` on your host machine and all ssh
+connections inside your container will use your `ssh-agent` on the host machine.
+
+**For OS X host machines (for Windows must work too).**
+
+Starting from Docker Desktop 2.2.0 (Jan 2020) a
+[new feature was added](https://github.com/docker/for-mac/issues/410), so you don't need to use an ugly hacks with
+socat, etc.
+
+All you need is to use special path `/run/host-services/ssh-auth.sock` that Docker recognizes and create special
+socket for `ssh-agent` on the host machine.
+
+Your `docker-compose.yml` must look like this:
+
+```yaml
+services:
+  virt-manager:
+    image: mber5/virt-manager:latest
+    restart: always
+    ports:
+      - 8185:80
+    environment:
+      DARK_MODE: false
+      HOSTS: "[]"
+      SSH_AUTH_SOCK: "/tmp/ssh_auth.sock"
+    volumes:
+      - "/run/host-services/ssh-auth.sock:/tmp/ssh-auth.sock"
+```
+
 ### Building from Dockerfile
 ```bash
     git clone https://github.com/m-bers/docker-virt-manager.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     # HOSTS: "['qemu+ssh://user@host1/system', 'qemu+ssh://user@host2/system']"
       HOSTS: "['qemu:///system']"
 
+    # If you want to use ssh-agent instead of copying ssh private keys specify path to the socket:
+    # SSH_AUTH_SOCK: "/tmp/ssh_auth.sock"
+    # Don't forget to uncomment corresponding settings in the `volumes` section.
+
     # If on an Ubuntu host (or any host with the libvirt AppArmor policy, you will need to use an ssh connection to localhost
     # or use qemu:///system and uncomment the below line to run the container in privileged mode: 
     # privileged: true
@@ -23,6 +27,11 @@ services:
 
     # If connecting to remote libvirtd, substitute location of ssh private key, e.g.:
       # - /home/user/.ssh/id_rsa:/root/.ssh/id_rsa:ro
+      # OR you may create a volume to pass ssh-agent socket instead of copying ssh private keys.
+      # For Linux:
+      # - "${SSH_AUTH_SOCK}:/tmp/ssh_auth.sock"
+      # For OS X and Windows:
+      # - "/run/host-services/ssh-auth.sock:/tmp/ssh-auth.sock"
     devices:
     # Not needed if connecting to remote libvirtd
       - "/dev/kvm:/dev/kvm"


### PR DESCRIPTION
Hi, @m-bers .

I want to present an improvement for `docker-virt-manager`. I tried to use this docker image and faced problems while using ssh keys with passphrases. You must enter passphrase a lot of times using `ttyd` approach (creation of a VM, creating connections, during an installation of VMs). It's pretty annoying, so I added manual how to act in a proper way with `ssh-agent` and passing `$SSH_AUTH_SOCK` to the container.

Fill free to comment and have a good day.
