### PR TITLE
Gracefully exit when the container gets `docker stop`-ped

### DIFF
--- a/startapp.sh
+++ b/startapp.sh
@@ -3,9 +3,10 @@
 /usr/local/bin/start
 
 # Note: No X server or wayland support--only cli and gtk3
-# ↓↓↓ PUT COMAMNDS HERE ↓↓↓
+# ↓↓↓ PUT COMMANDS HERE ↓↓↓
 dbus-launch gsettings set org.virt-manager.virt-manager.connections uris "$HOSTS"
 dbus-launch gsettings set org.virt-manager.virt-manager.connections autoconnect "$HOSTS"
 dbus-launch gsettings set org.virt-manager.virt-manager xmleditor-enabled true
 tmux send-keys -t ttyd dbus-launch\ virt-manager\ --no-fork Enter
-sleep infinity
+trap 'exit 0' SIGTERM
+while true; do sleep 1; done


### PR DESCRIPTION
This patch allows "somewhat graceful" exits from the docker container, allowing to stop the service without having to wait the timeout everytime (10 seconds by default).

I do not know if this is the most elegant way to do this, but it is probably the simplest one.